### PR TITLE
Removed the navigation button outline from both chrome and firefox

### DIFF
--- a/_sass/overlay_nav.scss
+++ b/_sass/overlay_nav.scss
@@ -58,6 +58,14 @@ nav.overlay {
   }
 }
 
+#main-nav-toggle:focus {
+  outline: 0;
+}
+
+#main-nav-toggle::-moz-focus-inner{
+  border: 0;
+}
+
 #main-nav-toggle {
   position: absolute;
   top: 30px;


### PR DESCRIPTION
The button outline in chrome showed up as a square blue border in chrome and a  square dotted border in firefox... I've removed it 