### PR TITLE
Repurpose signup component and add it to fix-analytics-specific page

### DIFF
--- a/_includes/fix-analytics-footer.html
+++ b/_includes/fix-analytics-footer.html
@@ -1,4 +1,4 @@
-<footer class="footer u-mt-lg">
+<footer class="footer">
   <div class="container">
     <div class="footer__content">
       <img class="footer__logo" src="/img/somanylogos/1.png">

--- a/_includes/fix-analytics-navigation.html
+++ b/_includes/fix-analytics-navigation.html
@@ -4,7 +4,10 @@
       Fix<br />Analytics
     </a>
     <div class="spacer"></div>
-    <a class="button button--dashed button--dark" href="signup">
+    <a
+      class="button button--dashed button--dark"
+      href="/fix-analytics/signup/"
+    >
       Sign up
     </a>
   </div>

--- a/_includes/fix_analytics_signup_form.html
+++ b/_includes/fix_analytics_signup_form.html
@@ -15,293 +15,297 @@
             />
             <!-- This is a honeypot, it is invisible to users, but not to bots. If it has value, it means it is a bot -->
         </label>
-        <div class="contact-form" data-form-step-1>
-            <h2>{% if lang_da %} Tilmeld til Fix-Analytics {% else %} Signup to Fix-Analytics {% endif %}</h2>
-            <p>
-                {% if lang_da %}Skriv adressen på din webside, f.eks. your-domain.dk.{% else %} The adress to your web site, fx. your-domain.com. {% endif %}
-            </p>
-            <div data-domains-container>
-                <label>
-                    <span>{% if lang_da %} Domæne {% else %} Domain {% endif %}</span>
-                    <input
-                        placeholder="your-domain.com"
-                        type="text"
-                        name="domain_1"
-                        value=""
-                        required
-                        data-domain-field
-                    />
-                </label>
-            </div>
-            <div class="u-text-right">
+        <div class="contact-form card" data-form-step-1>
+            <div class="card__body">
+                <h2>{% if lang_da %} Tilmeld til Fix-Analytics {% else %} Signup to Fix-Analytics {% endif %}</h2>
+                <p>
+                    {% if lang_da %}Skriv adressen på din webside, f.eks. your-domain.dk.{% else %} The adress to your web site, fx. your-domain.com. {% endif %}
+                </p>
+                <div data-domains-container>
+                    <label>
+                        <span>{% if lang_da %} Domæne {% else %} Domain {% endif %}</span>
+                        <input
+                            placeholder="your-domain.com"
+                            type="text"
+                            name="domain_1"
+                            value=""
+                            required
+                            data-domain-field
+                        />
+                    </label>
+                </div>
+                <div class="u-text-right text---right">
+                    <button
+                        class="button button--small button--dashed"
+                        data-add-additional-domain
+                    >
+                        <strong>+</strong>{% if lang_da %} Tilføj flere domæner {% else %} Add additional domain {% endif %}
+                    </button>
+                </div>
+                <span>
+                    {% if lang_da %}
+                        Pris pr domæne: 37 dk.
+                    {% else %}
+                        Price per domain: € 5.
+                    {% endif %}
+                </span>
+                <p>
+                    {% if lang_da %}
+                        Total pris: <strong><span data-price-dkk>0</span> kr.</strong>
+                    {% else %}
+                        Total price: <strong>€ <span data-price-eur>0</span></strong>
+                    {% endif %}
+                </p>
                 <button
-                    class="button button--small"
-                    data-add-additional-domain
+                    class="button u-mt-sm"
+                    data-toggel-form-state
+                    disabled
                 >
-                    <strong>+</strong>{% if lang_da %} Tilføj flere domæner {% else %} Add additional domain {% endif %}
+                    {% if lang_da %} Gå til fakturering {% else %} Go to billing {% endif %}
                 </button>
             </div>
-            <span>
-                {% if lang_da %}
-                    Pris pr domæne: 37 dk.
-                {% else %}
-                    Price per domain: € 5.
-                {% endif %}
-            </span>
-            <p>
-                {% if lang_da %}
-                    Total pris: <strong><span data-price-dkk>0</span> kr.</strong>
-                {% else %}
-                    Total price: <strong>€ <span data-price-eur>0</span></strong>
-                {% endif %}
-            </p>
-            <button
-                class="button"
-                data-toggel-form-state
-                disabled
-            >
-                {% if lang_da %} Gå til fakturering {% else %} Go to billing {% endif %}
-            </button>
         </div>
-        <div class="contact-form u-hide" data-form-step-2>
-            <input hidden name="currency" value="{% if lang_da %}DKK{% else %}EUR{% endif %}" />
-            <input hidden name="locale" value="{% if lang_da %}da_DK{% else %}en_US{% endif %}" />
-            <div class="contact-form__navigation">
-                <a
-                    class="contact-form__navigation-item"
-                    href="#"
-                    data-toggel-form-state
-                >
-                    ⤌{% if lang_da %} Tilbage til domæner {% else %} Back to domains {% endif %}
-                </a>
-            </div>
-            <h2>
-                {% if lang_da %} Faktureringsinformation {% else %} Billing information{% endif %}
-            </h2>
-            <label>
-                <span> {% if lang_da %} Kundetype {% else %} Customer Type {% endif %} </span>
-                <select
-                    name="type"
-                    required
-                    data-toggle-customer-type
-                >
-                    <option value="company">
-                        {% if lang_da %} Virksomhed {% else %} Company {% endif %}
-                    </option>
-                    <option value="person">
-                        {% if lang_da %} Privatperson {% else %} Individual {% endif %}
-                    </option>
-                </select>
-            </label>
-            <label>
-                <span data-company-name-label> {% if lang_da %} Firmanavn {% else %} Company name {% endif %} </span>
-                <span data-private-name-label hidden> {% if lang_da %} Navn {% else %} Name {% endif %} </span>
-                <input
-                    type="text"
-                    name="name"
-                    required
-                />
-            </label>
-            <label>
-                <span>{% if lang_da %} Kontaktperson {% else %} Contact person {% endif %}</span>
-                <input
-                    type="text"
-                    name="contactName"
-                    required
-                    data-contact-name-field
-                />
-            </label>
-            <label>
-                <span>
-                    {% if lang_da %}
-                        Vejnavn og vejnummer
-                    {% else %}
-                        Street and street number
-                    {% endif %}
-                </span>
-                <input
-                    type="text"
-                    name="street"
-                    required
-                />
-            </label>
-            <div class="two-col-inputs">
-                <label>
-                    <span> {% if lang_da %} By {% else %} City {% endif %} </span>
-                    <input
-                        type="text"
-                        name="city"
-                        required
-                    />
-                </label>
-                <label for="">
-                    <span> {% if lang_da %} Postnummer {% else %} Zip code {% endif %} </span>
-                    <input
-                        type="number"
-                        name="zipcode"
-                        required
-                    />
-                </label>
-            </div>
-            <div class="two-col-inputs">
-                <label for="">
-                    <span>
-                        {% if lang_da %} Stat (valgfri) {% else %} State (optional) {% endif %}
-                    </span>
-                    <input
-                        type="text"
-                        name="state"
-                    />
-                </label>
-                <label>
-                    <span>
-                        {% if lang_da %} Land {% else %} Country {% endif %} *
-                    </span>
-                    <select
-                        name="countryId"
-                        required
+        <div class="contact-form card u-hide" data-form-step-2>
+            <div class="card__body">
+                <input hidden name="currency" value="{% if lang_da %}DKK{% else %}EUR{% endif %}" />
+                <input hidden name="locale" value="{% if lang_da %}da_DK{% else %}en_US{% endif %}" />
+                <div class="contact-form__navigation u-mb-md">
+                    <a
+                        class="contact-form__navigation-item"
+                        href="#"
+                        data-toggel-form-state
                     >
-                        <option value="DK">Danmark</option>
-                        <option value="NO">Norge</option>
-                        <option value="SE">Sverige</option>
+                        ⤌{% if lang_da %} Tilbage til domæner {% else %} Back to domains {% endif %}
+                    </a>
+                </div>
+                <h2>
+                    {% if lang_da %} Faktureringsinformation {% else %} Billing information{% endif %}
+                </h2>
+                <label>
+                    <span> {% if lang_da %} Kundetype {% else %} Customer Type {% endif %} </span>
+                    <select
+                        name="type"
+                        required
+                        data-toggle-customer-type
+                    >
+                        <option value="company">
+                            {% if lang_da %} Virksomhed {% else %} Company {% endif %}
+                        </option>
+                        <option value="person">
+                            {% if lang_da %} Privatperson {% else %} Individual {% endif %}
+                        </option>
                     </select>
                 </label>
+                <label>
+                    <span data-company-name-label> {% if lang_da %} Firmanavn {% else %} Company name {% endif %} </span>
+                    <span data-private-name-label hidden> {% if lang_da %} Navn {% else %} Name {% endif %} </span>
+                    <input
+                        type="text"
+                        name="name"
+                        required
+                    />
+                </label>
+                <label>
+                    <span>{% if lang_da %} Kontaktperson {% else %} Contact person {% endif %}</span>
+                    <input
+                        type="text"
+                        name="contactName"
+                        required
+                        data-contact-name-field
+                    />
+                </label>
+                <label>
+                    <span>
+                        {% if lang_da %}
+                            Vejnavn og vejnummer
+                        {% else %}
+                            Street and street number
+                        {% endif %}
+                    </span>
+                    <input
+                        type="text"
+                        name="street"
+                        required
+                    />
+                </label>
+                <div class="two-col-inputs">
+                    <label>
+                        <span> {% if lang_da %} By {% else %} City {% endif %} </span>
+                        <input
+                            type="text"
+                            name="city"
+                            required
+                        />
+                    </label>
+                    <label for="">
+                        <span> {% if lang_da %} Postnummer {% else %} Zip code {% endif %} </span>
+                        <input
+                            type="number"
+                            name="zipcode"
+                            required
+                        />
+                    </label>
+                </div>
+                <div class="two-col-inputs">
+                    <label for="">
+                        <span>
+                            {% if lang_da %} Stat (valgfri) {% else %} State (optional) {% endif %}
+                        </span>
+                        <input
+                            type="text"
+                            name="state"
+                        />
+                    </label>
+                    <label>
+                        <span>
+                            {% if lang_da %} Land {% else %} Country {% endif %} *
+                        </span>
+                        <select
+                            name="countryId"
+                            required
+                        >
+                            <option value="DK">Danmark</option>
+                            <option value="NO">Norge</option>
+                            <option value="SE">Sverige</option>
+                        </select>
+                    </label>
+                </div>
+                <label>
+                    <span>
+                        {% if lang_da %}
+                            * Er dit land ikke på listen? <a href="mailto:get+analytics@deranged.dk">Skriv os en mail</a>, så finder vi ud af det.
+                        {% else %}
+                            * Is your country missing from the list? <a href="mailto:get+analytics@deranged.dk">Email us</a> and we will fix it.
+                        {% endif %}
+                    </span>
+                </label>
+                <label>
+                    <span>Email</span>
+                    <input
+                        type="email"
+                        name="email"
+                        placeholder="user@domain.com"
+                        required
+                    />
+                </label>
+                <label>
+                    <span> {% if lang_da %} Telefonnummer {% else %} Phone number {% endif %} </span>
+                    <input
+                        type="tel"
+                        name="phone"
+                        required
+                    />
+                </label>
+                <label>
+                    <span>
+                        {% if lang_da %}
+                            CVR
+                        {% else %}
+                            Company registration no.
+                        {% endif %}
+                    </span>
+                    <input
+                        type="text"
+                        name="registrationNo"
+                        required
+                        data-registration-no-field
+                    />
+                </label>
+                <label>
+                    <span>
+                        {% if lang_da %} Rabatkode (valgfri) {% else %} Discount Voucher (optional) {% endif %}
+                    </span>
+                    <input
+                        type="text"
+                        name="voucher"
+                    />
+                </label>
+                <label class="checkbox-container">
+                    <span>
+                        {% if lang_da %}
+                            Må vi vise jeres navn og logo på vores hjemmeside for at vise at I bruger vores løsning?
+                        {% else %}
+                            Can we use your name and logo on our website to show that you use our solution?
+                        {% endif %}
+                    </span>
+                    <input
+                        type="checkbox"
+                        name="useLogoAndName"
+                    />
+                </label>
+                <label class="checkbox-container">
+                    <span>
+                        {% if lang_da %}
+                            Må vi kontakte jer med henblik på at profilere jer som en privacy-bevidst virksomhed i branding relateret til Fix Analytics-produktet?
+                        {% else %}
+                            Can we contact you for the purpose of profiling you as a privacy-conscious company in branding related to the Fix Analytics product?
+                        {% endif %}
+                    </span>
+                    <input
+                        type="checkbox"
+                        name="contactForProfiling"
+                    />
+                </label>
+                <label class="checkbox-container">
+                    <span>
+                        {% if lang_da %}
+                            Jeg accepterer <a target="_blank" href="/fix-google-analytics/vilkaar">vilkår og databehandleraftale</a>
+                        {% else %}
+                            I accept the <a target="_blank" href="/fix-google-analytics/vilkaar">terms and conditions</a>
+                        {% endif %}
+                    </span>
+                    <input
+                        required
+                        type="checkbox"
+                        name="accept_terms"
+                    />
+                </label>
+                <div
+                    class="u-hide"
+                    data-analytics-form-overlay
+                >
+                    <div class="contact-form-overlay__message contact-form-overlay__message--awaiting">
+                        {% if lang_da %}
+                            Sender...
+                        {% else %}
+                            Sending request...
+                        {% endif %}
+                    </div>
+                    <div class="contact-form-overlay__message contact-form-overlay__message--success">
+                        <h3>
+                            {% if lang_da %}
+                                Succes! 👍
+                            {% else %}
+                                Success! 👍
+                            {% endif %}
+                        </h3>
+                        <p>
+                            {% if lang_da %}
+                                Du modtager en mail med information omkring implementation.
+                            {% else %}
+                                Please confirm you have recieved an email and your order has been registered.
+                            {% endif %}
+                        </p>
+                    </div>
+                    <div class="contact-form-overlay__message contact-form-overlay__message--error">
+                        <h3>
+                            {% if lang_da %}
+                                Noget gik desværre galt - Prøv igen ❌
+                            {% else %}
+                                Something went wrong - try again! ❌
+                            {% endif %}
+                        </h3>
+                        <p data-detailed-error-message></p>
+                    </div>
+                </div>
+                <button
+                    class="button"
+                    type="submit"
+                    data-submit-form-button
+                >
+                    {% if lang_da %} Tilmeld {% else %} Signup {% endif %}
+                </button>
             </div>
-            <label>
-                <span>
-                    {% if lang_da %}
-                        * Er dit land ikke på listen? <a href="mailto:get+analytics@deranged.dk">Skriv os en mail</a>, så finder vi ud af det.
-                    {% else %}
-                        * Is your country missing from the list? <a href="mailto:get+analytics@deranged.dk">Email us</a> and we will fix it.
-                    {% endif %}
-                </span>
-            </label>
-            <label>
-                <span>Email</span>
-                <input
-                    type="email"
-                    name="email"
-                    placeholder="user@domain.com"
-                    required
-                />
-            </label>
-            <label>
-                <span> {% if lang_da %} Telefonnummer {% else %} Phone number {% endif %} </span>
-                <input
-                    type="tel"
-                    name="phone"
-                    required
-                />
-            </label>
-            <label>
-                <span>
-                    {% if lang_da %}
-                        CVR
-                    {% else %}
-                        Company registration no.
-                    {% endif %}
-                </span>
-                <input
-                    type="text"
-                    name="registrationNo"
-                    required
-                    data-registration-no-field
-                />
-            </label>
-            <label>
-                <span>
-                    {% if lang_da %} Rabatkode (valgfri) {% else %} Discount Voucher (optional) {% endif %}
-                </span>
-                <input
-                    type="text"
-                    name="voucher"
-                />
-            </label>
-            <label class="checkbox-container">
-                <span>
-                    {% if lang_da %}
-                        Må vi vise jeres navn og logo på vores hjemmeside for at vise at I bruger vores løsning?
-                    {% else %}
-                        Can we use your name and logo on our website to show that you use our solution?
-                    {% endif %}
-                </span>
-                <input
-                    type="checkbox"
-                    name="useLogoAndName"
-                />
-            </label>
-            <label class="checkbox-container">
-                <span>
-                    {% if lang_da %}
-                        Må vi kontakte jer med henblik på at profilere jer som en privacy-bevidst virksomhed i branding relateret til Fix Analytics-produktet?
-                    {% else %}
-                        Can we contact you for the purpose of profiling you as a privacy-conscious company in branding related to the Fix Analytics product?
-                    {% endif %}
-                </span>
-                <input
-                    type="checkbox"
-                    name="contactForProfiling"
-                />
-            </label>
-            <label class="checkbox-container">
-                <span>
-                    {% if lang_da %}
-                        Jeg accepterer <a target="_blank" href="/fix-google-analytics/vilkaar">vilkår og databehandleraftale</a>
-                    {% else %}
-                        I accept the <a target="_blank" href="/fix-google-analytics/vilkaar">terms and conditions</a>
-                    {% endif %}
-                </span>
-                <input
-                    required
-                    type="checkbox"
-                    name="accept_terms"
-                />
-            </label>
-            <div
-                class="u-hide"
-                data-analytics-form-overlay
-            >
-                <div class="contact-form-overlay__message contact-form-overlay__message--awaiting">
-                    {% if lang_da %}
-                        Sender...
-                    {% else %}
-                        Sending request...
-                    {% endif %}
-                </div>
-                <div class="contact-form-overlay__message contact-form-overlay__message--success">
-                    <h3>
-                        {% if lang_da %}
-                            Succes! 👍
-                        {% else %}
-                            Success! 👍
-                        {% endif %}
-                    </h3>
-                    <p>
-                        {% if lang_da %}
-                            Du modtager en mail med information omkring implementation.
-                        {% else %}
-                            Please confirm you have recieved an email and your order has been registered.
-                        {% endif %}
-                    </p>
-                </div>
-                <div class="contact-form-overlay__message contact-form-overlay__message--error">
-                    <h3>
-                        {% if lang_da %}
-                            Noget gik desværre galt - Prøv igen ❌
-                        {% else %}
-                            Something went wrong - try again! ❌
-                        {% endif %}
-                    </h3>
-                    <p data-detailed-error-message></p>
-                </div>
-            </div>
-            <button
-                class="button"
-                type="submit"
-                data-submit-form-button
-            >
-                {% if lang_da %} Tilmeld {% else %} Signup {% endif %}
-            </button>
         </div>
     </form>
 </section>

--- a/_sass/fix-analytics/button.scss
+++ b/_sass/fix-analytics/button.scss
@@ -1,5 +1,7 @@
 .button {
+    background-color: transparent;
     border-radius: $border-radius;
+    border: 1px solid $font-off-black;
     padding: 0.5rem 1rem;
     color: inherit;
     text-decoration: none;
@@ -12,7 +14,7 @@
 
 .button--dashed {
     background: transparent;
-    border: 1px dashed black;
+    border: 1px dashed $font-off-black;
     outline: 1px solid transparent;
     outline-offset: -3px;
     transition: outline 0.15s;
@@ -24,4 +26,13 @@
     &:hover, &:focus {
         outline-color: white;
     }
+}
+
+.button--disabled,
+.button:disabled {
+    background-color: transparent;
+    color: $border-grey;
+    cursor: default;
+    transform: none;
+    border-color: $border-grey;
 }

--- a/_sass/fix-analytics/contact-form.scss
+++ b/_sass/fix-analytics/contact-form.scss
@@ -1,0 +1,145 @@
+// OLD Signup form styling. Should be refactored/deleted when we have the time
+
+.contact-form {
+  width: 100%;
+  max-width: 550px;
+  position: relative;
+
+  // Use regular text color because the link color is too light to be used here.
+  a {
+      color: inherit;
+  }
+
+  label {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      margin-top: 10px;
+      margin-bottom: 10px;
+  }
+
+  label > span {
+      font-size: 0.8em;
+  }
+
+  input[type=text],
+  input[type=number],
+  input[type=password],
+  input[type=tel],
+  input[type=email],
+  select {
+      width: 100%;
+      padding: 8px;
+      font-family: inherit;
+      font-size: 0.9em;
+  }
+
+  textarea {
+      width: 100%;
+      height: 150px;
+      resize: none;
+      font-family: inherit;
+      padding: 8px;
+      font-size: 0.9em;
+
+      @media (max-width: 539px) {
+          height: 210px;
+      }
+  }
+
+  .checkbox-container {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      margin-top: 20px;
+      margin-bottom: 20px;
+
+      input[type=checkbox] {
+          margin-left: 10px;
+      }
+  }
+
+  .two-col-inputs {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-gap: 10px;
+      margin-bottom: 10px;
+
+      @media (max-width: 539px) {
+          display: block;
+      }
+
+      label {
+          margin-bottom: 0;
+      }
+  }
+}
+
+.honeypot {
+  margin: 0;
+  height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+  opacity: 0;
+  position: absolute;
+}
+
+.contact-form-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(27,43,58,0.9);
+  color: white;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.8em;
+  font-weight: 200;
+  display: flex;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.contact-form-overlay-clickthrough {
+  display: none;
+}
+
+.contact-form-overlay-visible {
+  opacity: 1;
+}
+
+.contact-form-overlay__message {
+  text-align: center;
+  display: none;
+}
+
+.contact-form-overlay__message--success {
+  .contact-form-overlay--success & {
+      display: block;
+  }
+}
+
+.contact-form-overlay__message--error {
+  .contact-form-overlay--error & {
+      display: block;
+  }
+}
+
+.contact-form-overlay__message--awaiting {
+  .contact-form-overlay--awaiting & {
+      display: block;
+  }
+}
+
+.contact-form__navigation {
+  margin-top: 10px;
+}
+
+.contact-form__navigation-item {
+  text-decoration: none;
+
+  &:hover {
+      text-decoration: underline;
+  }
+}

--- a/_sass/fix-analytics/hero-section.scss
+++ b/_sass/fix-analytics/hero-section.scss
@@ -1,6 +1,5 @@
 .hero-section {
   position: relative;
-  margin-bottom: 30px;
   overflow: hidden;
 }
 

--- a/_sass/fix-analytics/hero-section.scss
+++ b/_sass/fix-analytics/hero-section.scss
@@ -9,15 +9,20 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  background-size: cover;
   background-image:
-    linear-gradient(to bottom, transparent, $off-white),
+    linear-gradient(to bottom, transparent, $off-white 85%),
     url(/fix-analytics/screen-image-by-markus-winkler.jpg);
   background-position: left;
+  background-repeat: no-repeat;
 
   @media(min-width: $width-md) {
     background-position: top left;
   }
+}
+
+.hero-section__background--fixed {
+  background-attachment: fixed;
 }
 
 .hero-section__content {

--- a/_sass/fix-analytics/hero-section.scss
+++ b/_sass/fix-analytics/hero-section.scss
@@ -13,12 +13,8 @@
   background-image:
     linear-gradient(to bottom, transparent, $off-white 85%),
     url(/fix-analytics/screen-image-by-markus-winkler.jpg);
-  background-position: left;
+  background-position: top;
   background-repeat: no-repeat;
-
-  @media(min-width: $width-md) {
-    background-position: top left;
-  }
 }
 
 .hero-section__background--fixed {

--- a/_sass/fix-analytics/layout.scss
+++ b/_sass/fix-analytics/layout.scss
@@ -8,6 +8,7 @@
 .content-section {
   &+& {
     margin-top: 100px;
+    margin-bottom: 100px;
   }
 }
 

--- a/_sass/fix-analytics/text.scss
+++ b/_sass/fix-analytics/text.scss
@@ -72,16 +72,24 @@
 .text--large {
   font-size: 2rem;
 }
+
 .text--huge {
   font-size: 3rem;
 }
+
 .text--small {
   font-size: 0.8rem;
 }
+
 .text--centered {
-  text-align: center;
+  text-align: center !important;
   width: 100%;
 }
+
+.text---right {
+  text-align: right !important;
+}
+
 .text--shiny {
   background-clip: text;
   -moz-background-clip: text;

--- a/_sass/fix-analytics/utility.scss
+++ b/_sass/fix-analytics/utility.scss
@@ -63,13 +63,26 @@
   margin-bottom: 0.5rem !important;
 }
 
+.u-mt-xs {
+  margin-top: 0.5rem !important;
+}
+
 .u-mb-sm {
   margin-bottom: 0.75rem !important;
 }
 
 .u-mb-md { margin-bottom: 1rem !important; }
 .u-mt-md { margin-top: 1rem !important; }
+.u-mt-sm {
+  margin-top: 0.75rem !important;
+}
 
 .u-mt-lg {
 	margin-top: 4rem !important;
+}
+
+/* Visibility
+// ================================================== */
+.u-hide {
+  display: none !important;
 }

--- a/css/fix-analytics-pages.scss
+++ b/css/fix-analytics-pages.scss
@@ -14,3 +14,4 @@ permalink: /css/fix-analytics-pages.css
 @import 'fix-analytics/button';
 @import 'fix-analytics/footer';
 @import 'fix-analytics/utility';
+@import 'fix-analytics/contact-form';

--- a/da/fix-analytics/dandomain/index.html
+++ b/da/fix-analytics/dandomain/index.html
@@ -14,7 +14,7 @@ layout: fix-analytics-page
   </div>
 </div>
 
-<div class="container">
+<div class="container u-mb-md">
   <div class="card">
     <div class="card__body">
       <h2 class="card__header">

--- a/fix-analytics/signup/index.html
+++ b/fix-analytics/signup/index.html
@@ -1,0 +1,17 @@
+---
+title: Signup | Get GDPR-compliant with Fix Google Analytics
+layout: fix-analytics-page
+---
+<div class="hero-section">
+  <div class="hero-section__background hero-section__background--fixed"></div>
+  <div class="hero-section__content container">
+    <h1 class="heading heading--big">
+      Get GDPR-compliant with
+      <br>
+      Fix Analytics
+    </h1>
+    <div class="u-mt-lg">
+      {% include fix_analytics_signup_form.html language="english" %}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### Changes:
- Use our current Signup component in the Fix-analytics brand.
- Make sure it looks good (with the card layout) without changing it in the old layout. It is backwards compatible with the "deranged" style.
- Tweak the hero-section styling to make it work better across different sizes and use cases. I use it on the signup page.
-  

![image](https://user-images.githubusercontent.com/8166831/202191987-959ab2a2-f5d7-4607-aa91-c7bd761d8e62.png)
![image](https://user-images.githubusercontent.com/8166831/202192029-f5a69ff1-c36e-441e-aa86-759ae7ae0cd2.png)
![image](https://user-images.githubusercontent.com/8166831/202192095-738ab2cb-f6e5-4926-9c91-750ac8fc0847.png)
