### PR TITLE
Use detail tags to make the 2 different guides expand and collabsible

### DIFF
--- a/_sass/fix-analytics/button.scss
+++ b/_sass/fix-analytics/button.scss
@@ -19,12 +19,18 @@
     outline-offset: -3px;
     transition: outline 0.15s;
 
-    &.button--dark {
-        border-color: white;
+    &:hover,
+    &:focus {
+        outline-color: $font-off-black;
     }
 
-    &:hover, &:focus {
-        outline-color: white;
+    &.button--dark {
+        border-color: white;
+
+        &:hover,
+        &:focus {
+            outline-color: white;
+        }
     }
 }
 

--- a/da/fix-analytics/dandomain/index.html
+++ b/da/fix-analytics/dandomain/index.html
@@ -17,106 +17,105 @@ lang: "da_dk"
 
 <div class="container u-mb-lg">
   <section>
-    <h2 class="heading heading--medium u-mb-md">
+    <h2 class="heading heading--medium u-mb-lg">
       Hvilken version af DanDomain Webshop bruger du?
     </h2>
-    <p>
-      Hvis du bruger <strong>DanDomain Webshop</strong>, så kan du <a href="#1a">følge guiden videre hér fra 1a</a>.<br>
-      Hvis du bruger <strong>DanDomain Classic (Webshop8)</strong> så <a href="#1b">gå ned til step 1b</a>.
-    </p>
-  </section>
 
-  <section class="u-mt-lg">
-    <h2 class="heading heading--small u-mb-md">
-      DanDomain Webshop Guide
-    </h2>
-    <div class="card">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="1a">
-          <strong>Step 1a:</strong> Log ind og gå til 'Apps'
-        </h3>
-        <p>
-          Log ind på din Dandomain Webshop og tryk på menupunktet 'Apps' i menuen til venstre.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-1a.jpg" target="_blank">
-          <img alt="dandomain guide billede 1a" src="/da/fix-analytics/dandomain/image-1a.jpg" />
-        </a>
+    <!-- Guide #1 -->
+    <details>
+      <summary class="button button--dashed heading heading--small" id="dandomain-webshop-guide">
+        DanDomain Webshop Guide
+      </summary>
+      <div class="card u-mt-md">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="1a">
+            <strong>Step 1a:</strong> Log ind og gå til 'Apps'
+          </h3>
+          <p>
+            Log ind på din Dandomain Webshop og tryk på menupunktet 'Apps' i menuen til venstre.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-1a.jpg" target="_blank">
+            <img alt="dandomain guide billede 1a" src="/da/fix-analytics/dandomain/image-1a.jpg" />
+          </a>
+        </div>
       </div>
-    </div>
 
-    <div class="card  u-mt-lg">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="2a">
-          <strong>Step 2a:</strong> Find app'en 'Google Analytics' og tryk 'Indstillinger'
-        </h3>
-        <p>
-          Du skal måske lede lidt for at finde den i listen.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-2a.jpg" target="_blank">
-          <img alt="dandomain guide billede 2a" src="/da/fix-analytics/dandomain/image-2a.jpg" />
-        </a>
+      <div class="card  u-mt-lg">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="2a">
+            <strong>Step 2a:</strong> Find app'en 'Google Analytics' og tryk 'Indstillinger'
+          </h3>
+          <p>
+            Du skal måske lede lidt for at finde den i listen.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-2a.jpg" target="_blank">
+            <img alt="dandomain guide billede 2a" src="/da/fix-analytics/dandomain/image-2a.jpg" />
+          </a>
+        </div>
       </div>
-    </div>
 
-    <div class="card u-mt-lg">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="3a">
-          <strong>Step 3a:</strong> Indsæt nye indstillinger
-        </h3>
-        <p>
-          Tryk 'Brug proxy / transport url til Google Analytics' for at vise feltet hvor du indtaster 'https://ga-proxy.deranged.dk'. Husk at trykke 'Gem' bagefet.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-3a.jpg" target="_blank">
-          <img alt="dandomain guide billede 3a" src="/da/fix-analytics/dandomain/image-3a.jpg" />
-        </a>
+      <div class="card u-mt-lg">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="3a">
+            <strong>Step 3a:</strong> Indsæt nye indstillinger
+          </h3>
+          <p>
+            Tryk 'Brug proxy / transport url til Google Analytics' for at vise feltet hvor du indtaster 'https://ga-proxy.deranged.dk'. Husk at trykke 'Gem' bagefet.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-3a.jpg" target="_blank">
+            <img alt="dandomain guide billede 3a" src="/da/fix-analytics/dandomain/image-3a.jpg" />
+          </a>
+        </div>
       </div>
-    </div>
-  </section>
+    </details>
 
-  <section class="u-mt-lg">
-    <h2 class="heading heading--small u-mb-md">
-      DanDomain Classic (Webshop8)
-    </h2>
-    <div class="card">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="1b">
-          <strong>Step 1b:</strong> Log ind og gå til 'Shopindstillinger'
-        </h3>
-        <p>
-          Du finder det ved at trykke 'Indstillinger', derefter 'Shopindstillinger'.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-1b.jpg" target="_blank">
-          <img alt="dandomain guide billede 1b" src="/da/fix-analytics/dandomain/image-1b.jpg" />
-        </a>
-      </div>
-    </div>
 
-    <div class="card u-mt-lg">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="2b">
-          <strong>Step 2b:</strong> Gå til 'Tracking og Feeds'?
-        </h3>
-        <p>
-          Du finder punktet inde på midten af siden.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-2b.jpg" target="_blank">
-          <img alt="dandomain guide billede 2b" src="/da/fix-analytics/dandomain/image-2b.jpg" />
-        </a>
+    <!-- Guide #2 -->
+    <details class="u-mt-md">
+      <summary class="button button--dashed heading heading--small" id="dandomain-classic-guide">
+        DanDomain Classic (Webshop8)
+      </summary>
+      <div class="card u-mt-md">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="1b">
+            <strong>Step 1b:</strong> Log ind og gå til 'Shopindstillinger'
+          </h3>
+          <p>
+            Du finder det ved at trykke 'Indstillinger', derefter 'Shopindstillinger'.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-1b.jpg" target="_blank">
+            <img alt="dandomain guide billede 1b" src="/da/fix-analytics/dandomain/image-1b.jpg" />
+          </a>
+        </div>
       </div>
-    </div>
 
-    <div class="card u-mt-lg">
-      <div class="card__body">
-        <h3 class="card__header heading--x-small" id="3b">
-          <strong>Step 3b:</strong> Indsæt nye indstillinger
-        </h3>
-        <p>
-          Under 'Tracking' finder du punktet 'Alternativ analytics URL' hvor du indtaster 'https://ga-proxy.deranged.dk'. Husk at trykke 'Gem'.
-        </p>
-        <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-3b.jpg" target="_blank">
-          <img alt="dandomain guide billede 3b" src="/da/fix-analytics/dandomain/image-3b.jpg" />
-        </a>
+      <div class="card u-mt-lg">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="2b">
+            <strong>Step 2b:</strong> Gå til 'Tracking og Feeds'?
+          </h3>
+          <p>
+            Du finder punktet inde på midten af siden.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-2b.jpg" target="_blank">
+            <img alt="dandomain guide billede 2b" src="/da/fix-analytics/dandomain/image-2b.jpg" />
+          </a>
+        </div>
       </div>
-    </div>
+
+      <div class="card u-mt-lg">
+        <div class="card__body">
+          <h3 class="card__header heading--x-small" id="3b">
+            <strong>Step 3b:</strong> Indsæt nye indstillinger
+          </h3>
+          <p>
+            Under 'Tracking' finder du punktet 'Alternativ analytics URL' hvor du indtaster 'https://ga-proxy.deranged.dk'. Husk at trykke 'Gem'.
+          </p>
+          <a class="u-mt-md" href="/da/fix-analytics/dandomain/image-3b.jpg" target="_blank">
+            <img alt="dandomain guide billede 3b" src="/da/fix-analytics/dandomain/image-3b.jpg" />
+          </a>
+        </div>
+      </div>
+    </details>
   </section>
 </div>


### PR DESCRIPTION
## Changes:
- Made the 2 guides into expandable/collapsible sections.
- Hopefully gives the user a better overview, and makes it clear that there are 2 different guides.
- It is possible to deeplink to each guide with a anchor in the URL. Such as `http://localhost:4000/da/fix-analytics/dandomain/#dandomain-webshop-guide` or `http://localhost:4000/da/fix-analytics/dandomain/#dandomain-classic-guide`.
- Had to fix a little CSS too.

## Caps:
![image](https://user-images.githubusercontent.com/8166831/203076035-7225b81e-853d-4f47-98eb-1ffb8f513b61.png)
![image](https://user-images.githubusercontent.com/8166831/203076057-5fff2d7b-a29c-4884-bf74-6524448eb2e3.png)
![image](https://user-images.githubusercontent.com/8166831/203076156-01716a7b-8c66-46eb-bfd1-86db2e72c397.png)
