### PR TITLE
Create dialog element styling

### DIFF
--- a/_sass/fix-analytics/dialog.scss
+++ b/_sass/fix-analytics/dialog.scss
@@ -2,6 +2,7 @@
   max-width: 560px;
   width: 100%;
   max-height: 100%;
+  position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);

--- a/_sass/fix-analytics/dialog.scss
+++ b/_sass/fix-analytics/dialog.scss
@@ -1,0 +1,45 @@
+.dialog {
+  max-width: 560px;
+  width: 100%;
+  max-height: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: $border-radius;
+  box-shadow: $overlay-shadow, $plastic-material-shadow;
+  border: none;
+  background-color: white;
+  padding: 0;
+
+  @media(min-width: $width-md) {
+    max-height: 560px;
+  }
+}
+
+.dialog__body {
+  padding: 1rem 1.25rem;
+}
+
+.dialog__actions {
+  padding: 1rem 1.25rem;
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: flex-end;
+  background-color: white;
+  border-top: 1px solid $border-grey;
+  gap: 10px;
+}
+
+// Overlay/backdrop styling
+.dialog::backdrop {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 1px,
+    rgba(0, 0, 0, 0.3) 1px,
+    rgba(0, 0, 0, 0.3) 20px
+  );
+  backdrop-filter: blur(3px);
+}

--- a/css/fix-analytics-pages.scss
+++ b/css/fix-analytics-pages.scss
@@ -6,6 +6,7 @@ permalink: /css/fix-analytics-pages.css
 @import 'fix-analytics/layout';
 @import 'fix-analytics/link';
 @import 'fix-analytics/card';
+@import 'fix-analytics/dialog';
 @import 'fix-analytics/navigation';
 @import 'fix-analytics/logo';
 @import 'fix-analytics/text';


### PR DESCRIPTION
### Changes:
- Add custom styling for dialog components

This snippet can be used to test locally:
```
 <button onClick="window.test_modal.showModal();">open modal</button>
  <dialog class="dialog" id="test_modal">
    <div class="dialog__body">
      <h3>wwowowow</h3>
      <p>
        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime voluptates impedit nobis a minima, quisquam libero voluptatem beatae recusandae. Deleniti blanditiis quidem et qui tempora consequatur amet porro! Molestias, ipsa.
      </p>
    </div>
    <div class="dialog__actions">
      <button class="button" onclick="window.test_modal.close();">Cancel</button>
      <button class="button" onclick="window.test_modal.close();">Okay</button>
    </div>
  </dialog>
```

### Screenshot:
 
![image](https://user-images.githubusercontent.com/8166831/205079587-61815660-341e-4590-a0d4-669192ff0bb6.png)
![image](https://user-images.githubusercontent.com/8166831/205079738-8d69fdd8-53eb-4a54-9764-3a9e352e557b.png)
![image](https://user-images.githubusercontent.com/8166831/205079758-2f571003-e95c-42cd-9794-bda0097c0060.png)
