### PR TITLE
Simplify Fancy-Text effect CSS

### DIFF
--- a/_sass/fix-analytics/text.scss
+++ b/_sass/fix-analytics/text.scss
@@ -60,7 +60,6 @@
 }
 
 .text--fancy {
-  //outline: 1px solid blue;
   position: relative;
   z-index: 2;
   display: inline-block;
@@ -78,6 +77,7 @@
     -webkit-text-stroke-width: 1px;
     display: block;
     white-space: pre-wrap;
+    content: attr(data-text-fancy);
   }
 
   &::before {
@@ -90,26 +90,6 @@
     -webkit-text-stroke-color: rgb(255,80,80);
     transform: translate(4px,4px);
   }
-}
-
-.text__fastest--fancy:before,
-.text__fastest--fancy:after {
-  content: 'fastest';
-}
-
-.text__fastest-da--fancy:before,
-.text__fastest-da--fancy:after {
-  content: 'hurtigste';
-}
-
-.text__cheapest--fancy:before,
-.text__cheapest--fancy:after {
-  content: 'cheapest';
-}
-
-.text__cheapest-da--fancy:before,
-.text__cheapest-da--fancy:after {
-  content: 'billigste';
 }
 
 .text--large {

--- a/da/fix-analytics/index.html
+++ b/da/fix-analytics/index.html
@@ -4,7 +4,7 @@ layout: fix-analytics-page
 lang: "da_dk"
 text_content:
   hero:
-    title: Den <em class="heading__emphasis text--fancy text__fastest-da--fancy">hurtigste</em> og <em class="heading__emphasis text--fancy text__cheapest-da--fancy">billigste</em> måde at forblive GDPR-compliant
+    title: Den <em class="heading__emphasis text--fancy" data-text-fancy="hurtigste">hurtigste</em> og <em class="heading__emphasis text--fancy" data-text-fancy="billigste">billigste</em> måde at forblive GDPR-compliant
     subtitle: for Google Analytics brugere
     usp1: <strong>75-90% billigere</strong> end sammenlignelige alternativer
     usp2: <strong>10 minutters</strong><br>opsætning

--- a/fix-analytics/index.html
+++ b/fix-analytics/index.html
@@ -4,7 +4,7 @@ layout: fix-analytics-page
 lang: "en_us"
 text_content:
   hero:
-    title: The <em class="heading__emphasis text--fancy text__fastest--fancy">fastest</em> and <em class="heading__emphasis text--fancy text__cheapest--fancy">cheapest</em> way to stay GDPR-compliant
+    title: The <em class="heading__emphasis text--fancy" data-text-fancy="fastest">fastest</em> and <em class="heading__emphasis text--fancy" data-text-fancy="cheapest">cheapest</em> way to stay GDPR-compliant
     subtitle: for users of Google Analytics
     usp1: <strong>75-90% cheaper</strong> than comparable alternatives
     usp2: <strong>10 minute</strong><br>setup


### PR DESCRIPTION
### Changes:
- Use data-attribute to show the fancy text effect.
- Removes the need for having modifier classes with hardcoded text.