### PR TITLE
Add link to switch from english to danish and vice-versa.

### DIFF
--- a/_includes/fix-analytics-navigation.html
+++ b/_includes/fix-analytics-navigation.html
@@ -1,17 +1,25 @@
 {% assign signup_text = "Sign up" %}
+{% assign change_lang_text = "🇩🇰 Danish" %}
 
 {% if include.lang == "da_dk" %}
     {% assign signup_text = "Køb nu" %}
     {% assign lang = "/da" %}
+    {% assign change_lang_text = "🇬🇧 English" %}
 {% endif %}
 
 <nav class="navigation">
-  <div class="container flex flex-wrap flex-align--center">
+  <div class="container flex flex-wrap align-items--center">
     <a class="logo" href="{{lang}}/fix-analytics/">
       Fix<br />Analytics<br />
       <span class="logo__deranged-attribution">by deranged</span>
     </a>
     <div class="spacer"></div>
+    <a
+      class="mr-sm"
+      href="{% if lang != '/da' %}/da{% endif %}{{page.url | remove: "/da"}}"
+    >
+      {{ change_lang_text }}
+    </a>
     <a
       class="button button--dashed button--dark"
       href="{{lang}}/fix-analytics/signup/"


### PR DESCRIPTION
Language switcher is very simple now. It will get the current url (and remove /da if you are on the danish version) and point to the other language. Works on all page, if they have a counterpart in the opposite language.

### Changes:
- Add link that can go to the danish/english version of your current page.
- Fix util class in nav, that was not correct.

### Screenshots:
![image](https://user-images.githubusercontent.com/8166831/212301276-cc0e2ed9-059e-45ae-85d0-e65345b33ad3.png)
![image](https://user-images.githubusercontent.com/8166831/212301311-d60debf4-7f96-4f94-85d2-368ba7b88f3d.png)
