### PR TITLE
Fix language switcher link for fix-analytics/dandomain

### DIFF
--- a/_includes/fix-analytics-navigation.html
+++ b/_includes/fix-analytics-navigation.html
@@ -7,6 +7,14 @@
     {% assign change_lang_text = "🇬🇧 English" %}
 {% endif %}
 
+{%- capture switch_lang_url -%}
+  {%- if lang != '/da' -%}
+      /da{{ page.url }}
+  {%- else -%}
+    {{ page.url | remove_first: "/da" }}
+  {% endif %}
+{%- endcapture -%}
+
 <nav class="navigation">
   <div class="container flex flex-wrap align-items--center">
     <a class="logo" href="{{lang}}/fix-analytics/">
@@ -16,7 +24,7 @@
     <div class="spacer"></div>
     <a
       class="mr-sm"
-      href="{% if lang != '/da' %}/da{% endif %}{{page.url | remove: "/da"}}"
+      href="{{switch_lang_url}}"
     >
       {{ change_lang_text }}
     </a>


### PR DESCRIPTION
Our logic was stripping `/da` in `/dandomain` which will lead to 404. Created better logic and made it a litte more readable.