### PR TITLE
Cookie-notice is now more robust on smaller screen

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,8 +32,8 @@
 					'We use a single cookie on our website, in order to count visitors.',
 					'Unlike most websites, however, it stores no identifiable information, does not track you across the internet, and passes no information on to third parties.',
 					'<a href="/privacy/#cookie">Read more</a>.',
+					'</p>',
 					'<button>Accept</button>',
-					'</p>'
 				].join(" ");
 				cookieNotice.querySelector("button").addEventListener("click", function(e) {
 					cookieNotice.classList += " cookie-notice-hide";

--- a/_layouts/fix-analytics-page.html
+++ b/_layouts/fix-analytics-page.html
@@ -31,8 +31,8 @@
 					'We use a single cookie on our website, in order to count visitors.',
 					'Unlike most websites, however, it stores no identifiable information, does not track you across the internet, and passes no information on to third parties.',
 					'<a href="/privacy/#cookie">Read more</a>.',
+					'</p>',
 					'<button>Accept</button>',
-					'</p>'
 				].join(" ");
 				cookieNotice.querySelector("button").addEventListener("click", function(e) {
 					cookieNotice.classList += " cookie-notice-hide";

--- a/_sass/fix-analytics/cookie-notice.scss
+++ b/_sass/fix-analytics/cookie-notice.scss
@@ -30,8 +30,8 @@
       padding: 4px 14px;
       box-sizing: border-box;
       cursor: pointer;
-      position: absolute;
-      right: 15px;
+      margin-left: auto;
+      display: block;
   }
 
   &.cookie-notice-hide {

--- a/css/style.scss
+++ b/css/style.scss
@@ -151,9 +151,8 @@ main p {
         padding: 4px 14px;
         box-sizing: border-box;
         cursor: pointer;
-        position: absolute;
-        bottom: 14px;
-        right: 15px;
+        margin-left: auto;
+        display: block;
     }
 
     &.cookie-notice-hide {


### PR DESCRIPTION
Text should never overlap with "accept" button.
Having the button as a block element under the paragraph, should give the same look but ensure that the elements do not overlap.

### screenshot:
![Screenshot from 2023-03-13 10-29-36](https://user-images.githubusercontent.com/8166831/224661999-10061593-a7eb-4427-aca9-f81e38311f95.png)
![Screenshot from 2023-03-13 10-33-39](https://user-images.githubusercontent.com/8166831/224662345-ab503c9a-ef9a-4d79-a2fa-6eddf1937d58.png)

![Screenshot from 2023-03-13 10-33-51](https://user-images.githubusercontent.com/8166831/224662381-329c4f71-d6b0-44b9-b442-7296010666f3.png)
