### PR TITLE
Quote fix

### DIFF
--- a/_includes/get_a_quote.html
+++ b/_includes/get_a_quote.html
@@ -1,6 +1,10 @@
 <section class="rest-sales">
     <h2 class="rest-sales__title">
-        {{ include.title || "Get a quote" }}
+        {% if  include.title %}
+            {{include.title}}
+        {% else %}
+            Get a quote
+        {% endif %}
     </h2>
     {% if include.hide_pitch != "true" %}
     <p>


### PR DESCRIPTION
Fixed if include statement
The way it was wrote before resulted in the default 'Get a quote' title not being displayed at all