### PR TITLE
Fixed header text color for service page layout

### DIFF
--- a/_layouts/services.html
+++ b/_layouts/services.html
@@ -61,6 +61,7 @@ layout: default
 
   .main-content .header {
     width: 100%;
+    color: #2c3e50
   }
   .main-content .header__row {
     display: flex;


### PR DESCRIPTION
Before:
<img width="1658" height="1165" alt="image" src="https://github.com/user-attachments/assets/331906e1-9067-4358-a958-f491f07cec9b" />
