### PR TITLE
Accessibility page photos layout redo

### DIFF
--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -14,7 +14,7 @@ h6 {
     word-wrap: break-word;
     overflow-wrap: break-word;
 
-    @media(max-width: 767px) {
+    @media(max-width: $width-md) {
         hyphens: auto;
     }
 }
@@ -91,7 +91,7 @@ h6 {
         object-fit: cover;
         max-height: 260px;
         width: 100%;
-        box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+        box-shadow: $overlay-shadow;
 
         @media (min-width: 768px) {
             height: 260px;
@@ -106,7 +106,7 @@ h6 {
         margin: 0;
         grid-column: 1 / span 2;
         grid-row: 1 / span 2;
-        box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+        box-shadow: $overlay-shadow;
 
         img {
             display: block;

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -114,7 +114,7 @@ figcaption {
             height: 440px;
         }
         .photo-caption {
-            margin: 1rem 0.8rem;
+            margin: 1rem 1.8rem;
             transform: translate(0, 0) scale(1.2);
         }
     }

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -19,10 +19,6 @@ h6 {
     }
 }
 
-.content__container--full-width {
-    max-width: 100%;
-}
-
 .content:has(.request-contact--standalone) {
     padding-bottom: 24rem;
 
@@ -66,7 +62,7 @@ h6 {
 .section__two-col {
     display: grid;
     grid-template-columns: 1fr;
-    column-gap: 1rem;
+    column-gap: 3rem;
 
     @media (min-width: 768px) {
         grid-template-columns: 1fr 1fr;
@@ -78,10 +74,12 @@ h6 {
     display: grid;
     width: 80%;
     justify-self: center;
+    column-gap: 0;
 
     @media (min-width: 768px) {
         width: 100%;
         grid-template-columns: 1fr 1fr;
+        column-gap: 2rem;
     }
 
     @media (min-width: 400px) {
@@ -108,7 +106,6 @@ h6 {
         margin: 0;
         grid-column: 1 / span 2;
         grid-row: 1 / span 2;
-        transform: translate(0, 0) scale(0.9);
         box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
 
         img {
@@ -130,19 +127,35 @@ h6 {
     }
 
     div:nth-of-type(1) img {
-      transform: translate(-16%, 22%) scale(1);
+        transform: translate(8%, -4%) scale(1.2);
+
+        @media (max-width: 1600px) {
+            transform: translate(8%, 0) scale(1.1);
+        }
     }
 
     div:nth-of-type(2) img {
-      transform: translate(-24%, 12%) scale(1);
+        transform: translate(65%, -25%) scale(1.2);
+
+        @media (max-width: 1600px) {
+            transform: translate(15%, -10%) scale(1.1);
+        }
     }
 
     div:nth-of-type(3) img {
-      transform: translate(0, 12%) scale(1);
+        transform: translate(37%, 12%) scale(1.2);
+
+        @media (max-width: 1600px) {
+            transform: translate(17%, 4%) scale(1.1);
+        }
     }
 
     div:nth-of-type(4) img {
-      transform: translate(-3%, 14%) scale(1);
+        transform: translate(56%, 27%) scale(1.2);
+
+        @media (max-width: 1600px) {
+            transform: translate(-4%, 18%) scale(1.1);
+        }
     }
 }
 
@@ -172,6 +185,18 @@ h6 {
 
 .section__cta--no-margin-top {
     margin-top: 0;
+}
+
+.section__cta--two-col {
+    display: grid;
+    grid-template-columns: 1fr;
+    justify-items: center;
+
+    @media (min-width: 768px) {
+        grid-template-columns: 1fr 1fr;
+        column-gap: 3rem;
+        justify-items: start;
+    }
 }
 
 .section__cta--centered {

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -23,21 +23,6 @@ h6 {
     max-width: 100%;
 }
 
-.content__image-container {
-    max-width: 300px;
-    margin: auto;
-
-    img {
-        width: 100%;
-        border-radius: 4px;
-    }
-
-    @media (min-width: 768px) {
-        float: right;
-        margin: 1rem 2.25rem;
-    }
-}
-
 .content:has(.request-contact--standalone) {
     padding-bottom: 24rem;
 
@@ -48,13 +33,6 @@ h6 {
 
 .content:has(.request-contact--standalone) + .content {
     padding-top: 12rem;
-}
-
-figcaption {
-    font-size: 0.875rem;
-    color: #666;
-    margin-top: 0.5rem;
-    text-align: center;
 }
 
 .section__heading {
@@ -145,8 +123,9 @@ figcaption {
         }
 
         .photo-caption {
-            margin: 1rem 1.8rem;
-            transform: translate(0, 0) scale(1.2);
+            text-align: center;
+            margin: 0.8rem;
+            font-size: 1.1rem;
         }
     }
 

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -88,42 +88,51 @@ figcaption {
 .section__two-col {
     display: grid;
     grid-template-columns: 1fr 1fr;
+    column-gap: 1rem;
 }
 
 .team-photos {
     align-content: center;
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
 
     img {
         object-fit: cover;
-        height: 300px;
+        height: 260px;
         width: 100%;
         box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
     }
 
+    figure {
+        margin: 0;
+        grid-column: 1 / span 2;
+        grid-row: 1 / span 2;
+        transform: translate(0, 0) scale(0.9);
+        box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+        img {
+            box-shadow: none;
+            height: 440px;
+        }
+        .photo-caption {
+            margin: 1rem 0.8rem;
+            transform: translate(0, 0) scale(1.2);
+        }
+    }
+
     div:nth-of-type(1) img {
-      transform: translate(-10%, -15%) scale(0.8);
+      transform: translate(-16%, 22%) scale(1);
     }
 
     div:nth-of-type(2) img {
-      transform: translate(-15%, 10%) scale(1.1);
+      transform: translate(-24%, 12%) scale(1);
     }
 
     div:nth-of-type(3) img {
-      transform: translate(-12%, -20%) scale(0.9);
+      transform: translate(0, 12%) scale(1);
     }
 
     div:nth-of-type(4) img {
-      transform: translate(5%, -5%) scale(0.85);
-    }
-
-    div:nth-of-type(5) img {
-      transform: translate(-3%, 3%) scale(0.8);
-    }
-
-    div:nth-of-type(6) img {
-      transform: translate(-5%, -15%) scale(0.9);
+      transform: translate(-3%, 14%) scale(1);
     }
 }
 

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -87,20 +87,43 @@ figcaption {
 
 .section__two-col {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     column-gap: 1rem;
+
+    @media (min-width: 768px) {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 
 .team-photos {
     align-content: center;
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    width: 80%;
+    justify-self: center;
+
+    @media (min-width: 768px) {
+        width: 100%;
+        grid-template-columns: 1fr 1fr;
+    }
+
+    @media (min-width: 400px) {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
 
     img {
+        display: none;
         object-fit: cover;
-        height: 260px;
+        max-height: 260px;
         width: 100%;
         box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+
+        @media (min-width: 768px) {
+            height: 260px;
+        }
+
+        @media (min-width: 400px) {
+            display: block;
+        }
     }
 
     figure {
@@ -109,10 +132,18 @@ figcaption {
         grid-row: 1 / span 2;
         transform: translate(0, 0) scale(0.9);
         box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+
         img {
+            display: block;
             box-shadow: none;
-            height: 440px;
+            max-height: 440px;
+            width: 100%;
+
+            @media (min-width: 768px) {
+                height: 440px;
+            }
         }
+
         .photo-caption {
             margin: 1rem 1.8rem;
             transform: translate(0, 0) scale(1.2);

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -85,6 +85,48 @@ figcaption {
     }
 }
 
+.section__two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+}
+
+.team-photos {
+    align-content: center;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+
+    img {
+        object-fit: cover;
+        height: 300px;
+        width: 100%;
+        box-shadow: 0 6px 5px rgba(0,0,0,0.2), 0 4px 3px rgba(0,0,0,0.05);
+    }
+
+    div:nth-of-type(1) img {
+      transform: translate(-10%, -15%) scale(0.8);
+    }
+
+    div:nth-of-type(2) img {
+      transform: translate(-15%, 10%) scale(1.1);
+    }
+
+    div:nth-of-type(3) img {
+      transform: translate(-12%, -20%) scale(0.9);
+    }
+
+    div:nth-of-type(4) img {
+      transform: translate(5%, -5%) scale(0.85);
+    }
+
+    div:nth-of-type(5) img {
+      transform: translate(-3%, 3%) scale(0.8);
+    }
+
+    div:nth-of-type(6) img {
+      transform: translate(-5%, -15%) scale(0.9);
+    }
+}
+
 .section__cta {
     display: flex;
     gap: 2rem;

--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -73,7 +73,7 @@ h6 {
     }
 }
 
-.team-photos {
+.section__team-photos {
     align-content: center;
     display: grid;
     width: 80%;

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -88,21 +88,15 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container">
+    <div class="content__container content__container--wide">
       <h2 class="section__heading">
         Your accessibility team
       </h2>
-      <div>
+      <div class="section__two-col">
         <div class="section__text">
           <p>
             ➟ deranged offers a wide range of consulting services within web accessibility.
           </p>
-          <figure class="content__image-container">
-            <img src="/img/people/anne-tingaengelighed.jpg" alt="" />
-            <figcaption>
-              Anne Thyme Nørregaard, Staff Consultant in Web Accessibility
-            </figcaption>
-          </figure>
           <p>
             Our staff consultant in web accessibility, Anne Thyme Nørregaard, has 10+ years of experience within accessibility and is a Certified Professional in Web Accessibility (CPWA), the highest level of certification offered by the International Association of Accessibility Professionals (IAAP). Anne has helped countless public authorities and private companies upgrade their employees’ skills and ensure accessibility on their websites, apps and software.
           </p>
@@ -112,6 +106,14 @@ questions:
           <p>
             deranged is also a development house, so in addition to delivering skills training and “diagnostics” within web accessibility, we can also offer you that our development team fixes your accessibility issues for you! Our development team can help you whether it is an existing solution that needs fixing, or if you need something new developed that complies with the European Accessibility Act (EAA, for the private sector) or the Web Accessibility Directive (WAD, for the public sector). We can also help you fix accessibility issues you have discovered through other means, e.g. from automated testing tools or a monitoring report.
           </p>
+        </div>
+        <div class="team-photos">
+          <div><img src="/img/people/asbjoern-thegler.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/haidar.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/philip-dein.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/anders.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/niels-abildgaard.jpg" alt="" loading="lazy" class="team_member"/></div>
         </div>
       </div>
       <div class="section__cta section__cta--no-margin-top">

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -107,7 +107,7 @@ questions:
             deranged is also a development house, so in addition to delivering skills training and “diagnostics” within web accessibility, we can also offer you that our development team fixes your accessibility issues for you! Our development team can help you whether it is an existing solution that needs fixing, or if you need something new developed that complies with the European Accessibility Act (EAA, for the private sector) or the Web Accessibility Directive (WAD, for the public sector). We can also help you fix accessibility issues you have discovered through other means, e.g. from automated testing tools or a monitoring report.
           </p>
         </div>
-        <div class="team-photos">
+        <div class="section__team-photos">
           <figure>
             <img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/>
             <figcaption class="photo-caption">Anne Thyme Nørregaard, Staff Consultant in Web Accessibility</figcaption>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -108,9 +108,11 @@ questions:
           </p>
         </div>
         <div class="team-photos">
+          <figure>
+            <img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/>
+            <figcaption class="photo-caption">Anne Thyme Nørregaard, Staff Consultant in Web Accessibility</figcaption>
+          </figure>
           <div><img src="/img/people/asbjoern-thegler.jpg" alt="" loading="lazy" class="team_member"/></div>
-          <div><img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/></div>
-          <div><img src="/img/people/haidar.jpg" alt="" loading="lazy" class="team_member"/></div>
           <div><img src="/img/people/philip-dein.jpg" alt="" loading="lazy" class="team_member"/></div>
           <div><img src="/img/people/anders.jpg" alt="" loading="lazy" class="team_member"/></div>
           <div><img src="/img/people/niels-abildgaard.jpg" alt="" loading="lazy" class="team_member"/></div>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -88,7 +88,7 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container content__container--extra-wide">
+    <div class="content__container content__container--wide">
       <h2 class="section__heading">
         Your accessibility team
       </h2>

--- a/accessibility/index.html
+++ b/accessibility/index.html
@@ -88,7 +88,7 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container content__container--wide">
+    <div class="content__container content__container--extra-wide">
       <h2 class="section__heading">
         Your accessibility team
       </h2>
@@ -118,7 +118,7 @@ questions:
           <div><img src="/img/people/niels-abildgaard.jpg" alt="" loading="lazy" class="team_member"/></div>
         </div>
       </div>
-      <div class="section__cta section__cta--no-margin-top">
+      <div class="section__cta section__cta--extra-margin-top section__cta--two-col">
         <a class="button button--with-border" href="#services">
           See our services within web accessibility
         </a>

--- a/css/home.scss
+++ b/css/home.scss
@@ -982,3 +982,8 @@ permalink: /css/homestyle.css
 .content__container--wide {
   max-width: 1200px;
 }
+
+.content__container--extra-wide {
+    max-width: 1400px;
+}
+

--- a/css/home.scss
+++ b/css/home.scss
@@ -983,7 +983,3 @@ permalink: /css/homestyle.css
   max-width: 1200px;
 }
 
-.content__container--extra-wide {
-    max-width: 1400px;
-}
-

--- a/da/tilgaengelighed/index.html
+++ b/da/tilgaengelighed/index.html
@@ -88,7 +88,7 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container content__container--wide">
+    <div class="content__container content__container--extra-wide">
       <h2 class="section__heading">
         Dit tilgængelighedsteam
       </h2>
@@ -115,7 +115,7 @@ questions:
           <div><img src="/img/people/niels-abildgaard.jpg" alt="" loading="lazy" class="team_member"/></div>
         </div>
       </div>
-      <div class="section__cta section__cta--no-margin-top">
+      <div class="section__cta section__cta--extra-margin-top section__cta--two-col">
         <a class="button button--with-border" href="#services">
           Se vores ydelser inden for webtilgængelighed
         </a>

--- a/da/tilgaengelighed/index.html
+++ b/da/tilgaengelighed/index.html
@@ -88,27 +88,31 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container">
+    <div class="content__container content__container--wide">
       <h2 class="section__heading">
         Dit tilgængelighedsteam
       </h2>
-      <div>
+      <div class="section__two-col">
         <div class="section__text">
           <p>
             ➟ deranged tilbyder en bred række konsulentydelser inden for webtilgængelighed.
           </p>
-          <figure class="content__image-container">
-            <img src="/img/people/anne-tingaengelighed.jpg" alt="" />
-            <figcaption>
-              Anne Thyme Nørregaard, Staff konsulent i webtilgængelighed
-            </figcaption>
-          </figure>
           <p>
             Vores staff konsulent i webtilgængelighed, Anne Thyme Nørregaard, har 10+ års erfaring inden for tilgængelighed og er Certified Professional in Web Accessibility (CPWA), som er den højeste niveau certificering, der tilbydes fra International Association of Accessibility Professionals (IAAP), og deranged er blandt andet leverandør til Digitaliseringsstyrelsen på opgaven med at monitorere om offentlige myndigheders websteder og apps lever op til kravene i webtilgængelighedsloven. Anne har hjulpet utallige offentlige myndigheder og private virksomheder med at opkvalificere deres medarbejdere og sikre tilgængeligheden på deres websteder, i apps og i software.
           </p>
           <p>
             deranged er også et udviklingshus, så ud over at vi leverer opkvalificering og ”diagnosticering” inden for webtilgængelighed, kan vi også tilbyde dig, at vores udviklingsteam løser dine tilgængelighedsproblemer for dig! Vores udviklingsteam kan hjælpe dig både hvis det er en eksisterende løsning, der skal fikses, og hvis du skal have udviklet noget nyt, der lever op til tilgængelighedsloven (for den private sektor) eller webtilgængelighedsloven (for den offentlige sektor). Vi kan også hjælpe dig med at fikse tilgængelighedsproblemer, som du har fået kendskab til ad andre veje, fx fra automatiske testværktøjer eller en monitoreringsrapport.
           </p>
+        </div>
+        <div class="team-photos">
+          <figure>
+            <img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/>
+            <figcaption class="photo-caption">Anne Thyme Nørregaard, Staff konsulent i webtilgængelighed</figcaption>
+          </figure>
+          <div><img src="/img/people/asbjoern-thegler.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/philip-dein.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/anders.jpg" alt="" loading="lazy" class="team_member"/></div>
+          <div><img src="/img/people/niels-abildgaard.jpg" alt="" loading="lazy" class="team_member"/></div>
         </div>
       </div>
       <div class="section__cta section__cta--no-margin-top">

--- a/da/tilgaengelighed/index.html
+++ b/da/tilgaengelighed/index.html
@@ -104,7 +104,7 @@ questions:
             deranged er også et udviklingshus, så ud over at vi leverer opkvalificering og ”diagnosticering” inden for webtilgængelighed, kan vi også tilbyde dig, at vores udviklingsteam løser dine tilgængelighedsproblemer for dig! Vores udviklingsteam kan hjælpe dig både hvis det er en eksisterende løsning, der skal fikses, og hvis du skal have udviklet noget nyt, der lever op til tilgængelighedsloven (for den private sektor) eller webtilgængelighedsloven (for den offentlige sektor). Vi kan også hjælpe dig med at fikse tilgængelighedsproblemer, som du har fået kendskab til ad andre veje, fx fra automatiske testværktøjer eller en monitoreringsrapport.
           </p>
         </div>
-        <div class="team-photos">
+        <div class="section__team-photos">
           <figure>
             <img src="/img/people/anne-tingaengelighed.jpg" alt="" loading="lazy" class="team_member"/>
             <figcaption class="photo-caption">Anne Thyme Nørregaard, Staff konsulent i webtilgængelighed</figcaption>

--- a/da/tilgaengelighed/index.html
+++ b/da/tilgaengelighed/index.html
@@ -88,7 +88,7 @@ questions:
   </section>
 
   <section class="content content--blue">
-    <div class="content__container content__container--extra-wide">
+    <div class="content__container content__container--wide">
       <h2 class="section__heading">
         Dit tilgængelighedsteam
       </h2>


### PR DESCRIPTION
From Niels:

> Idea for the accessibility page: can we use the new idea we designed for the team preview section, with team member images somewhat offset from each other, on this page as well? Keep Anne highlighted and with a little label box explaining who she is, but add the rest of the team as smaller images floating off to the side?
> I think this could fill out some of the empty space that would otherwise be left by having Ann's picture alone next side-by-side with the text, which is why the text is currently wrapped. So we could make the text not wrap, just be side-by-side, and have a growing element of team pictures on the right-hand side.  

(new idea for the team preview section comes from: https://github.com/derangeddk/deranged.dk/pull/159 )
<img width="1737" height="991" alt="image (5)" src="https://github.com/user-attachments/assets/008fdc0b-87b0-4ff6-8b65-b0cd3b635b7f" />
<img width="1683" height="861" alt="image (4)" src="https://github.com/user-attachments/assets/4eae7697-b511-49af-b7cf-c3826219283b" />

To see changes

- Visit https://deploy-preview-171--zealous-fermat-77bc7b.netlify.app/accessibility/ and scroll down to section with header "Your accessibility team"
- the same changes should be visible in the danish version of the page: https://deploy-preview-171--zealous-fermat-77bc7b.netlify.app/da/tilgaengelighed/