### PR TITLE
Added dark link color to variables and fixed content class links colors

### DIFF
--- a/_layouts/services.html
+++ b/_layouts/services.html
@@ -146,7 +146,7 @@ layout: default
     color: #eaf1f7;
   }
   .main-content :nth-child(even of .content-row) a:not(a.button) {
-    color: #0e3661;
+    color: var(--deranged-dark-link);
   }
   .main-content .content-row__title {
     grid-column: 2;

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -4,12 +4,14 @@ $deranged-light-background: #ecf0f1;
 $deranged-light-blue: #455d75;
 $deranged-dark-blue: #2c3e50;
 $deranged-darkened-blue: #1b2b3a;
+$deranged-dark-link: #0e3661;
 
 :root {
   --deranged-text: #{$deranged-text};
   --deranged-light-background: #{$deranged-light-background};
   --deranged-light-blue: #{$deranged-light-blue};
   --deranged-dark-blue: #{$deranged-dark-blue};
+  --deranged-dark-link: #{$deranged-dark-link};
 }
 
 // Breakpoints

--- a/css/home.scss
+++ b/css/home.scss
@@ -922,9 +922,8 @@ permalink: /css/homestyle.css
       padding: 5rem 2rem;
     }
 
-    a:not([class]) {
-      color: inherit;
-      text-decoration: underline;
+    a:not(.content--blue a, a.button) {
+      color: $deranged-dark-link;
     }
   }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -434,5 +434,5 @@ h3, .heading-3 {
     font-size: 1.5rem;
 }
 .longform a {
-    color: #0e3661;
+    color: $deranged-dark-link;
 }


### PR DESCRIPTION
Fixed colors of the textual links on the /accessibility, da/tilgaengelighed/, /revops and their respective sub-pages (/accessibility/fix-my-accessibility-issues/ and /da/tilgaengelighed/fiks-mine-tilgaengelighedsproblemer/)

edt: This PR should also fix the links colors appearing in cases pages (that will get added with https://github.com/derangeddk/deranged.dk/pull/154 PR)