### PR TITLE
fix improve certification section accessibility

### DIFF
--- a/_includes/certification.html
+++ b/_includes/certification.html
@@ -1,7 +1,7 @@
 <aside class="certification-section content--blue">
   <div class="certification-section__content">
     <div>
-      <img src="/img/smv_digital.svg" alt="" class="certification-section__content-logo" loading="lazy" />
+      <img src="/img/smv_digital.svg" alt="SMV Digital" class="certification-section__content-logo" loading="lazy" />
       <p>
         As registered advisors at
         <a href="https://smvdigital.dk/content/ydelser/tilbud/4e84e652-3d63-4b24-b5f5-a278d2ad27e6/">SMV:Digital</a>
@@ -9,13 +9,13 @@
       </p>
     </div>
     <div class="square-logo">
-      <img src="/img/leverandoer_logo_negativ_RGB.png" alt="" class="certification-section__content-logo" loading="lazy" />
+      <img src="/img/leverandoer_logo_negativ_RGB.png" alt="Ski supplier" class="certification-section__content-logo" loading="lazy" />
       <p>
         We are an approved SKI-supplier on the <a href="https://www.ski.dk/aftaler/se-aftale/?id=02140024">02.14 It-konsulenter (DIS)</a>-contract, so if you are a public sector organization in Denmark <a href="https://www.ski.dk/videnssider/sadan-bliver-du-kunde-hos-os/">you can significantly reduce the procurement process</a> while allowing us to bid.
       </p>
     </div>
     <div>
-      <img src="/img/dosl-logo-white.svg" alt="" class="certification-section__content-logo" loading="lazy" />
+      <img src="/img/dosl-logo-white.svg" alt="Danish open source suppliers" class="certification-section__content-logo" loading="lazy" />
       <p>
         With our network of open source software suppliers, centered around the organization of <a href="https://dosl.dk/">Danish Open Source Suppliers</a>—of which we are a founding member, we can help you navigate any transition to digital sovereignty.
       </p>


### PR DESCRIPTION
We have recently decided that is makes sense to not use alt tags for certification section logos  
See https://github.com/derangeddk/deranged.dk/pull/159/files/75581d40e673ca7024528b9c96eeb9bb53a05ffc#diff-5bf7e29e7af8e0dc411ed5f54b768e1e466a5c4143fd9fbf2ba2aa11e6631314 followed by https://github.com/derangeddk/deranged.dk/pull/159/commits/7586acdf7a044e7952b2b55e45353de383766a6f
But after revisiting this topic with @annethyme we came to a conclusion that it makes sense to keep the alt text for better accessibility