### PR TITLE
hide decorative icons on the homepage from accessiblity api

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
       <a href="https://github.com/derangeddk">GitHub</a>
     </span>
   </div>
-  <span class="footer-icon">↯</span>
+  <span class="footer-icon" aria-hidden="true">↯</span>
 </footer>
 
 <script>

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ sitemap_include: 'yes'
             We excel at solving these problems…
         </h1>
         <div class="segment">
-            <div class="segment__icon segment__icon--top segment__icon--arrow-1">
+            <div class="segment__icon segment__icon--top segment__icon--arrow-1" aria-hidden="true">
                 ☈
             </div>
             <div class="segment__item segment__item--problem">
@@ -144,12 +144,12 @@ sitemap_include: 'yes'
                     Check it out <span class="segment__cta-icon">↬</span>
                 </a>
             </div>
-            <div class="segment__icon segment__icon--bottom segment__icon--arrow-2">
+            <div class="segment__icon segment__icon--bottom segment__icon--arrow-2" aria-hidden="true">
                 ⟿
             </div>
         </div>
         <div class="segment">
-            <div class="segment__icon segment__icon--top segment__icon--arrow-3">
+            <div class="segment__icon segment__icon--top segment__icon--arrow-3" aria-hidden="true">
                 ↶
             </div>
             <div class="segment__item segment__item--problem">
@@ -186,12 +186,12 @@ sitemap_include: 'yes'
                     Check it out <span class="segment__cta-icon">⇝</span>
                 </a>
             </div>
-            <div class="segment__icon segment__icon--bottom segment__icon--arrow-4">
+            <div class="segment__icon segment__icon--bottom segment__icon--arrow-4" aria-hidden="true">
                 ↸
             </div>
         </div>
         <div class="segment">
-            <div class="segment__icon segment__icon--top segment__icon--arrow-5">
+            <div class="segment__icon segment__icon--top segment__icon--arrow-5" aria-hidden="true">
                 ⤰
             </div>
             <div class="segment__item segment__item--problem">
@@ -225,7 +225,7 @@ sitemap_include: 'yes'
                     Check it out <span class="segment__cta-icon">⇢</span>
                 </a>
             </div>
-            <div class="segment__icon segment__icon--bottom segment__icon--arrow-6">
+            <div class="segment__icon segment__icon--bottom segment__icon--arrow-6" aria-hidden="true">
                 ⥉
             </div>
         </div>


### PR DESCRIPTION
Hide utf-8 icons used for decorative purposes on the homepage from accessibility API so that screen readers will not read them