### PR TITLE
fix subpages list elements displayed off screen

### DIFF
--- a/_sass/accessibility-page.scss
+++ b/_sass/accessibility-page.scss
@@ -207,6 +207,10 @@ h6 {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 3rem;
+
+    @media(max-width: $width-md) {
+        grid-template-columns: 1fr;
+    }
 }
 
 .subpages-item__title {


### PR DESCRIPTION
Issue: Description of services on the Accessibility (and Revops) page is displayed off screen on mobile with 200% zoom