### PR TITLE
hide decorative icons from accessibility api - round 2

### DIFF
--- a/cases/index.html
+++ b/cases/index.html
@@ -65,14 +65,14 @@ sitemap_include: 'yes'
                 Cases
             </h1>
             <h2 class="display-2">
-                Some of the things <strong>we have worked on</strong> ↴
+                Some of the things <strong>we have worked on</strong><span aria-hidden="true"> ↴</span>
             </h2>
             <div class="hero__text-wrapper">
                 <p>
                     On this page, we have gathered a selection of work we have done. The cases are categorized by the type of work we primarily did in a case, but there is rarely a clean separation between the categories: we often do both operations, accessibility and development work in a single project.
                 </p>
                 <p>
-                    ⇳ Scroll through, or jump to a specific category if you know what you are looking for. Each case has a link to read more, if you find something of interest.
+                    <span aria-hidden="true">⇳ </span>Scroll through, or jump to a specific category if you know what you are looking for. Each case has a link to read more, if you find something of interest.
                 </p>
                 <ul>
                     {% for category in site.data.categories %}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ sitemap_include: 'yes'
         <h2>Let's start building your software&hellip;</h2>
     </div>
     <p class="quick-intro">
-        <span class="quick-intro-icon">➟</span>
+        <span class="quick-intro-icon" aria-hidden="true">➟</span>
         We hit the ground running on your software project. Our expert software development and operations team will help you to make the best decisions about software in your company.
         With flexiblity and engagement, we are your dev team.
     </p>
@@ -141,7 +141,7 @@ sitemap_include: 'yes'
                 CTO if you don't have one, or the role of directly supporting your CTO in the important
                 work they are doing.
                 <a class="segment__cta" href="">
-                    Check it out <span class="segment__cta-icon">↬</span>
+                    Check it out <span class="segment__cta-icon" aria-hidden="true">↬</span>
                 </a>
             </div>
             <div class="segment__icon segment__icon--bottom segment__icon--arrow-2" aria-hidden="true">
@@ -183,7 +183,7 @@ sitemap_include: 'yes'
                 We focus on long-term collaboration with all our customers so the knowledge we build is not wasted.
                 We're a plug and play team: plug us into your business and we will start delivering value.
                 <a class="segment__cta" href="">
-                    Check it out <span class="segment__cta-icon">⇝</span>
+                    Check it out <span class="segment__cta-icon" aria-hidden="true">⇝</span>
                 </a>
             </div>
             <div class="segment__icon segment__icon--bottom segment__icon--arrow-4" aria-hidden="true">
@@ -222,7 +222,7 @@ sitemap_include: 'yes'
                 We help software teams improve technical skills and how they work through pair programming,
                 coaching, and presentations tailored to the concrete team situation.
                 <a class="segment__cta" href="">
-                    Check it out <span class="segment__cta-icon">⇢</span>
+                    Check it out <span class="segment__cta-icon" aria-hidden="true">⇢</span>
                 </a>
             </div>
             <div class="segment__icon segment__icon--bottom segment__icon--arrow-6" aria-hidden="true">


### PR DESCRIPTION
Hide more utf-8 icons used for decorative purposes on various pages from accessibility API so that screen readers will not read them