### PR TITLE
Fix main nav accessibility

### DIFF
--- a/_includes/overlay_nav.html
+++ b/_includes/overlay_nav.html
@@ -7,7 +7,7 @@
   <div class="icon-bar"></div>
   <div class="icon-bar"></div>
 </button>
-<nav id="main-nav" class="main-nav overlay hidden" lang="en">
+<nav id="main-nav" class="main-nav overlay u-hide" lang="en">
   <div class="main-nav-menu" id="main-nav-menu">
     {% include menu_links.html %}
   </div>
@@ -20,8 +20,8 @@
     var nonNavElements = document.querySelectorAll(
       'body > :not(#main-nav, #main-nav-toggle)'
     );
-    if (classes.contains("hidden")) {
-      document.getElementById('main-nav').classList.toggle('hidden');
+    if (classes.contains("u-hide")) {
+      document.getElementById('main-nav').classList.toggle('u-hide');
       requestAnimationFrame(() => {
         document.querySelector("body").classList.toggle("main-nav-open");
       });
@@ -32,7 +32,7 @@
     } else {
       document.querySelector("body").classList.toggle("main-nav-open");
       setTimeout(() => {
-        document.getElementById('main-nav').classList.toggle('hidden');
+        document.getElementById('main-nav').classList.toggle('u-hide');
       }, 300);
       mainNavToggle.setAttribute('aria-label', 'Menu');
       nonNavElements.forEach(e => {

--- a/_includes/overlay_nav.html
+++ b/_includes/overlay_nav.html
@@ -7,24 +7,24 @@
   <div class="icon-bar"></div>
   <div class="icon-bar"></div>
 </button>
-<nav id="main-nav" class="main-nav overlay" lang="en">
-  <div class="main-nav-menu hidden" id="main-nav-menu">
+<nav id="main-nav" class="main-nav overlay hidden" lang="en">
+  <div class="main-nav-menu" id="main-nav-menu">
     {% include menu_links.html %}
   </div>
 </nav>
 
 <script>
   document.getElementById('main-nav-toggle').addEventListener("click", function () {
-    var classes = document.getElementById('main-nav-menu').classList;
+    var classes = document.getElementById('main-nav').classList;
     if (classes.contains("hidden")) {
-      document.getElementById('main-nav-menu').classList.toggle('hidden');
+      document.getElementById('main-nav').classList.toggle('hidden');
       requestAnimationFrame(() => {
         document.querySelector("body").classList.toggle("main-nav-open");
       });
     } else {
       document.querySelector("body").classList.toggle("main-nav-open");
       setTimeout(() => {
-        document.getElementById('main-nav-menu').classList.toggle('hidden');
+        document.getElementById('main-nav').classList.toggle('hidden');
       }, 300);
 
     };

--- a/_includes/overlay_nav.html
+++ b/_includes/overlay_nav.html
@@ -17,18 +17,27 @@
   document.getElementById('main-nav-toggle').addEventListener("click", function () {
     var classes = document.getElementById('main-nav').classList;
     var mainNavToggle = document.getElementById('main-nav-toggle');
+    var nonNavElements = document.querySelectorAll(
+      'body > :not(#main-nav, #main-nav-toggle)'
+    );
     if (classes.contains("hidden")) {
       document.getElementById('main-nav').classList.toggle('hidden');
       requestAnimationFrame(() => {
         document.querySelector("body").classList.toggle("main-nav-open");
       });
       mainNavToggle.setAttribute('aria-label', 'Close menu');
+      nonNavElements.forEach(e => {
+        e.setAttribute('inert', 'true');
+      });
     } else {
       document.querySelector("body").classList.toggle("main-nav-open");
       setTimeout(() => {
         document.getElementById('main-nav').classList.toggle('hidden');
       }, 300);
       mainNavToggle.setAttribute('aria-label', 'Menu');
+      nonNavElements.forEach(e => {
+        e.removeAttribute('inert');
+      });
     };
   });
 </script>

--- a/_includes/overlay_nav.html
+++ b/_includes/overlay_nav.html
@@ -16,17 +16,19 @@
 <script>
   document.getElementById('main-nav-toggle').addEventListener("click", function () {
     var classes = document.getElementById('main-nav').classList;
+    var mainNavToggle = document.getElementById('main-nav-toggle');
     if (classes.contains("hidden")) {
       document.getElementById('main-nav').classList.toggle('hidden');
       requestAnimationFrame(() => {
         document.querySelector("body").classList.toggle("main-nav-open");
       });
+      mainNavToggle.setAttribute('aria-label', 'Close menu');
     } else {
       document.querySelector("body").classList.toggle("main-nav-open");
       setTimeout(() => {
         document.getElementById('main-nav').classList.toggle('hidden');
       }, 300);
-
+      mainNavToggle.setAttribute('aria-label', 'Menu');
     };
   });
 </script>

--- a/_sass/overlay_nav.scss
+++ b/_sass/overlay_nav.scss
@@ -28,6 +28,9 @@ nav.overlay {
   z-index: -1;
   opacity: 0.0;
   transition: all 200ms ease;
+  &.hidden {
+    display: none;
+  }
   @media screen and (min-width: 768px) {
     nav.overlay:before {
        content: "\219D";
@@ -50,9 +53,6 @@ nav.overlay {
   height: 100%;
   max-width: 400px;
   margin-left: auto;
-  &.hidden {
-    display: none;
-  }
   a {
     display: block;
     text-align: right;

--- a/_sass/overlay_nav.scss
+++ b/_sass/overlay_nav.scss
@@ -28,9 +28,6 @@ nav.overlay {
   z-index: -1;
   opacity: 0.0;
   transition: all 200ms ease;
-  &.hidden {
-    display: none;
-  }
   @media screen and (min-width: 768px) {
     nav.overlay:before {
        content: "\219D";

--- a/_sass/overlay_nav.scss
+++ b/_sass/overlay_nav.scss
@@ -76,6 +76,9 @@ nav.overlay {
     &:hover:after {
       height: 60%;
     }
+    @media(max-height: 767px) {
+        padding: 0;
+    }
   }
 }
 

--- a/_sass/overlay_nav.scss
+++ b/_sass/overlay_nav.scss
@@ -79,10 +79,6 @@ nav.overlay {
   }
 }
 
-#main-nav-toggle:focus {
-  outline: 0;
-}
-
 #main-nav-toggle::-moz-focus-inner{
   border: 0;
 }


### PR DESCRIPTION
Code changes aiming at fixing issues with main nav menu:

- Menu button is missing focus indicator (introduced in https://github.com/derangeddk/deranged.dk/pull/17, ~~not sure why~~ and have an approval to revert it)
- When menu takes over whole screen, keyboard and screen reader navigation needs to be kept in the menu, and not enter into the page behind
- When menu button turns into a close button, this needs to be reflected in its accessible name
- Zooming into 400% on a 1280 x 800 px viewport breaks the menu
- 200% zoom on mobile also breaks the menu
- When the menu is closed, there is an empty nav area that is announced by screen readers